### PR TITLE
XTerm Mouse support

### DIFF
--- a/src/main/java/li/cil/oc2r/client/gui/AbstractMachineTerminalScreen.java
+++ b/src/main/java/li/cil/oc2r/client/gui/AbstractMachineTerminalScreen.java
@@ -80,6 +80,22 @@ public abstract class AbstractMachineTerminalScreen<T extends AbstractMachineTer
     }
 
     @Override
+    public boolean mouseClicked(final double x, final double y, final int button) {
+        if (!terminalWidget.mouseClicked(x,y,button)) {
+            return super.mouseClicked(x, y, button);
+        }
+        return true;
+    }
+
+    @Override
+    public boolean mouseReleased(final double x, final double y, final int button) {
+        if (!terminalWidget.mouseReleased(x,y,button)) {
+            return super.mouseReleased(x, y, button);
+        }
+        return true;
+    }
+
+    @Override
     public boolean keyPressed(final int keyCode, final int scanCode, final int modifiers) {
         if (terminalWidget.keyPressed(keyCode, scanCode, modifiers)) {
             return true;

--- a/src/main/java/li/cil/oc2r/client/gui/MachineTerminalWidget.java
+++ b/src/main/java/li/cil/oc2r/client/gui/MachineTerminalWidget.java
@@ -116,6 +116,40 @@ public final class MachineTerminalWidget {
             container.sendTerminalInputToServer(input);
         }
     }
+    
+    public boolean mouseClicked( double x, double y, int button) {
+        int mx = (int) x;
+        int my = (int) y;
+        int sx = (int)((x - MachineTerminalWidget.TERMINAL_X) / MachineTerminalWidget.TERMINAL_WIDTH * Terminal.WIDTH);
+        int sy = (int)((y - MachineTerminalWidget.TERMINAL_Y) / MachineTerminalWidget.TERMINAL_HEIGHT * Terminal.HEIGHT);
+        boolean overTerminal = isMouseOverTerminal(mx, my);
+        if (overTerminal && shouldCaptureInput()) {
+            terminal.putInput((byte) 0x1b);
+            terminal.putInput((byte) '[');
+            terminal.putInput((byte) button);
+            terminal.putInput((byte) sx);
+            terminal.putInput((byte) sy);
+            return true;
+        }
+        return false;
+    }
+    
+    public boolean mouseReleased( double x, double y, int button) {
+        int mx = (int) x;
+        int my = (int) y;
+        int sx = (int)((x - MachineTerminalWidget.TERMINAL_X) / MachineTerminalWidget.TERMINAL_WIDTH * Terminal.WIDTH);
+        int sy = (int)((y - MachineTerminalWidget.TERMINAL_Y) / MachineTerminalWidget.TERMINAL_HEIGHT * Terminal.HEIGHT);
+        boolean overTerminal = isMouseOverTerminal(mx, my);
+        if (overTerminal && shouldCaptureInput()) {
+            terminal.putInput((byte) 0x1b);
+            terminal.putInput((byte) '[');
+            terminal.putInput((byte) 3);
+            terminal.putInput((byte) sx);
+            terminal.putInput((byte) sy);
+            return true;
+        }
+        return false;
+    }
 
     public boolean charTyped(final char ch, final int modifier) {
         if (modifier == 0 || modifier == GLFW.GLFW_MOD_SHIFT) {


### PR DESCRIPTION
As requested.  The same patch should be applicable to 1.19 and 1.18 (I only extensively tested on 1.19).