### PR TITLE
Added try/catch for `ClassCastException`

### DIFF
--- a/src/main/java/li/cil/oc2/common/bus/device/provider/util/AbstractBlockEntityDeviceProvider.java
+++ b/src/main/java/li/cil/oc2/common/bus/device/provider/util/AbstractBlockEntityDeviceProvider.java
@@ -35,7 +35,11 @@ public abstract class AbstractBlockEntityDeviceProvider<T extends BlockEntity> e
             return Invalidatable.empty();
         }
 
-        return getBlockDevice(query, (T) blockEntity);
+        try {
+            return getBlockDevice(query, (T) blockEntity);
+        } catch (ClassCastException ignored) {
+            return Invalidatable.empty();
+        }
     }
 
     ///////////////////////////////////////////////////////////////////


### PR DESCRIPTION
If an implementation of `AbstractBlockEntityDeviceProvider` does not pass in a `BlockEntityType` (which they don't by default), then the game may crash as it will then attempt to cast *any* `BlockEntity` to whatever class the `AbstractBlockEntityDeviceProvider` was implemented for

I discovered this when trying to make my own generic `AbstractBehaviourDeviceProvider<T extends SmartBlockEntity>` class that extends `AbstractBlokcEntityDeviceProvider<T>`. Upon running the game, it crashed trying to cast the computer to `SmartBlockEntity`.

This can be solved with a simple try/catch when `AbstractBlockEntityDeviceProvider#getBlockDevice` is called within `AbstractBlockEntityDeviceProvider#getDevice` to ensure that, if the passed `BlockEntity` cannot be cast to the required class, it will fail silently and not crash the game upon world load.