### PR TITLE
terminal: Add sanitization of invalid Unicode characters

### DIFF
--- a/src/main/java/li/cil/oc2/common/vm/terminal/fonts/UnicodeFontRenderer.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/fonts/UnicodeFontRenderer.java
@@ -24,8 +24,13 @@ public class UnicodeFontRenderer {
         }
     }
 
+    // Sanitizes any invalid Unicode codepoints to the Unicode replacement character.
+    private static int sanitizeCharacter(int character) {
+        return Character.isValidCodePoint(character) ? character : 0xFFFD;
+    }
+
     public Glyph getGlyph(int character) {
-        return glyphCache.computeIfAbsent(character, this::rasterizeGlyph);
+        return glyphCache.computeIfAbsent(sanitizeCharacter(character), this::rasterizeGlyph);
     }
 
     private Glyph rasterizeGlyph(int character) {


### PR DESCRIPTION
This prevents a crash when doing operations such as `cat /dev/urandom`

Closes #70 