### PR TITLE
Fix projectors not working

### DIFF
--- a/src/main/java/li/cil/oc2/common/vm/provider/SimpleFramebufferDeviceProvider.java
+++ b/src/main/java/li/cil/oc2/common/vm/provider/SimpleFramebufferDeviceProvider.java
@@ -41,7 +41,6 @@ public final class SimpleFramebufferDeviceProvider implements DeviceTreeProvider
             .addProp("height", fb.getHeight())
             .addProp("stride", fb.getWidth() * SimpleFramebufferDevice.STRIDE)
             .addProp("format", "r5g6b5")
-            .addProp("no-map")
             .addProp(DevicePropertyNames.STATUS, "okay");
     }
 }

--- a/src/main/java/li/cil/oc2/common/vm/provider/SimpleFramebufferDeviceProvider.java
+++ b/src/main/java/li/cil/oc2/common/vm/provider/SimpleFramebufferDeviceProvider.java
@@ -24,7 +24,9 @@ public final class SimpleFramebufferDeviceProvider implements DeviceTreeProvider
         final Optional<MappedMemoryRange> range = memoryMap.getMemoryRange((MemoryMappedDevice) device);
         return range.map(r -> {
             final DeviceTree chosen = root.find("/chosen");
-            chosen.addProp(DevicePropertyNames.RANGES);
+            chosen.addProp(DevicePropertyNames.RANGES)
+                  .addProp("#address-cells", 2)
+                  .addProp("#size-cells", 2);
 
             return chosen.getChild(deviceName, r.address());
         });


### PR DESCRIPTION
I wondered why it doesn't work for long days, but when I use `dtc` to parse the FDT it generated today, it told me why:

> \<stdout\>: Warning (reg_format): /chosen/framebuffer@30000000:reg: property has invalid length (16 bytes) (#address-cells == 2, #size-cells == 1)