### PR TITLE
Fix inventory operation position math for adjancent blocks

### DIFF
--- a/src/main/java/li/cil/oc2/common/bus/device/rpc/item/InventoryOperationsModuleDevice.java
+++ b/src/main/java/li/cil/oc2/common/bus/device/rpc/item/InventoryOperationsModuleDevice.java
@@ -212,14 +212,15 @@ public final class InventoryOperationsModuleDevice extends AbstractItemRPCDevice
     }
 
     private Stream<IItemHandler> getItemStackHandlersInDirection(final Direction direction) {
-        return getItemStackHandlersAt(Vec3.atCenterOf(entity.blockPosition().relative(direction)), direction.getOpposite());
+        return getItemStackHandlersAt(entity.blockPosition().relative(direction), direction.getOpposite());
     }
 
-    private Stream<IItemHandler> getItemStackHandlersAt(final Vec3 position, final Direction side) {
-        return Stream.concat(getEntityItemHandlersAt(position, side), getBlockItemHandlersAt(position, side));
+    private Stream<IItemHandler> getItemStackHandlersAt(final BlockPos blockPos, final Direction side) {
+        return Stream.concat(getEntityItemHandlersAt(blockPos, side), getBlockItemHandlersAt(blockPos, side));
     }
 
-    private Stream<IItemHandler> getEntityItemHandlersAt(final Vec3 position, final Direction side) {
+    private Stream<IItemHandler> getEntityItemHandlersAt(final BlockPos blockPos, final Direction side) {
+        var position = Vec3.atCenterOf(blockPos);
         final AABB bounds = AABB.unitCubeFromLowerCorner(position.subtract(0.5, 0.5, 0.5));
         return entity.level().getEntities(entity, bounds).stream()
             .map(e -> e.getCapability(Capabilities.itemHandler(), side))
@@ -227,10 +228,8 @@ public final class InventoryOperationsModuleDevice extends AbstractItemRPCDevice
             .map(c -> c.orElseThrow(AssertionError::new));
     }
 
-    private Stream<IItemHandler> getBlockItemHandlersAt(final Vec3 position, final Direction side) {
-        Vec3i posi = new Vec3i((int) position.x, (int) position.y, (int) position.z);
-        final BlockPos pos = new BlockPos(posi);
-        final BlockEntity blockEntity = entity.level().getBlockEntity(pos);
+    private Stream<IItemHandler> getBlockItemHandlersAt(final BlockPos blockPos, final Direction side) {
+        final BlockEntity blockEntity = entity.level().getBlockEntity(blockPos);
         if (blockEntity == null) {
             return Stream.empty();
         }


### PR DESCRIPTION
Grabbing the center position of a block and then truncating it does not always return the initial block position, so move the position math into getEntityItemHandlersAt where it's needed, and keep the block position around for getBlockItemHandlersAt

This likely fixes https://github.com/North-Western-Development/oc2r/issues/82