### PR TITLE
1.21.1 Fixes

### DIFF
--- a/src/main/java/li/cil/oc2/client/renderer/ProjectorDepthRenderer.java
+++ b/src/main/java/li/cil/oc2/client/renderer/ProjectorDepthRenderer.java
@@ -16,6 +16,7 @@ import com.mojang.blaze3d.vertex.*;
 import com.mojang.math.Axis;
 import li.cil.oc2.api.API;
 import net.minecraft.client.DeltaTracker;
+import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.client.event.ClientTickEvent;
@@ -61,7 +62,7 @@ import static org.lwjgl.opengl.GL11.glDrawBuffer;
 import static org.lwjgl.opengl.GL30.GL_FRAMEBUFFER;
 import static org.lwjgl.opengl.GL30.glBindFramebuffer;
 
-@EventBusSubscriber(modid = API.MOD_ID)
+@EventBusSubscriber(modid = API.MOD_ID, value=Dist.CLIENT)
 public final class ProjectorDepthRenderer {
     private static final int DEPTH_CAPTURE_SIZE = 256;
 

--- a/src/main/java/li/cil/oc2/data/ModItemTagsProvider.java
+++ b/src/main/java/li/cil/oc2/data/ModItemTagsProvider.java
@@ -65,7 +65,8 @@ public final class ModItemTagsProvider extends ItemTagsProvider {
             Items.NETWORK_INTERFACE_CARD.get(),
             Items.FILE_IMPORT_EXPORT_CARD.get(),
             Items.SOUND_CARD.get(),
-            Items.NETWORK_TUNNEL_CARD.get()
+            Items.NETWORK_TUNNEL_CARD.get(),
+            Items.INTERNET_CARD.get()
         );
         tag(DEVICES_ROBOT_MODULE).add(
             Items.INVENTORY_OPERATIONS_MODULE.get(),

--- a/src/main/java/li/cil/oc2/data/ModRecipesProvider.java
+++ b/src/main/java/li/cil/oc2/data/ModRecipesProvider.java
@@ -2,7 +2,9 @@
 
 package li.cil.oc2.data;
 
+import li.cil.oc2.common.block.ComputerBlock;
 import li.cil.oc2.common.item.Items;
+import li.cil.oc2.common.item.RobotItem;
 import li.cil.oc2.common.item.crafting.WrenchRecipe;
 import net.minecraft.advancements.Criterion;
 import net.minecraft.advancements.critereon.InventoryChangeTrigger;
@@ -23,7 +25,7 @@ public final class ModRecipesProvider extends RecipeProvider {
     @Override
     protected void buildRecipes(final RecipeOutput consumer) {
         ShapedRecipeBuilder
-            .shaped(RecipeCategory.MISC, Items.COMPUTER.get())
+            .shaped(RecipeCategory.MISC, ComputerBlock.getComputerWithFlash())
             .pattern("ICI")
             .pattern("XTX")
             .pattern("IBI")
@@ -174,7 +176,7 @@ public final class ModRecipesProvider extends RecipeProvider {
             .save(consumer);
 
         ShapedRecipeBuilder
-            .shaped(RecipeCategory.MISC, Items.ROBOT.get())
+            .shaped(RecipeCategory.MISC, RobotItem.getRobotWithFlash())
             .pattern("ICI")
             .pattern("PTP")
             .pattern("IBI")

--- a/src/main/resources/data/oc2r/recipe/computer.json
+++ b/src/main/resources/data/oc2r/recipe/computer.json
@@ -24,6 +24,39 @@
     "IBI"
   ],
   "result": {
+    "components": {
+      "oc2r:restricted_container": {
+        "items": {
+          "oc2r:devices/card": [
+            {},
+            {},
+            {},
+            {}
+          ],
+          "oc2r:devices/cpu": [
+            {}
+          ],
+          "oc2r:devices/flash_memory": [
+            {
+              "count": 1,
+              "id": "oc2r:flash_memory_custom"
+            }
+          ],
+          "oc2r:devices/hard_drive": [
+            {},
+            {},
+            {},
+            {}
+          ],
+          "oc2r:devices/memory": [
+            {},
+            {},
+            {},
+            {}
+          ]
+        }
+      }
+    },
     "count": 1,
     "id": "oc2r:computer"
   }

--- a/src/main/resources/data/oc2r/recipe/robot.json
+++ b/src/main/resources/data/oc2r/recipe/robot.json
@@ -24,6 +24,37 @@
     "IBI"
   ],
   "result": {
+    "components": {
+      "oc2r:restricted_container": {
+        "items": {
+          "oc2r:devices/cpu": [
+            {}
+          ],
+          "oc2r:devices/flash_memory": [
+            {
+              "count": 1,
+              "id": "oc2r:flash_memory_custom"
+            }
+          ],
+          "oc2r:devices/hard_drive": [
+            {},
+            {}
+          ],
+          "oc2r:devices/memory": [
+            {},
+            {},
+            {},
+            {}
+          ],
+          "oc2r:devices/robot_module": [
+            {},
+            {},
+            {},
+            {}
+          ]
+        }
+      }
+    },
     "count": 1,
     "id": "oc2r:robot"
   }

--- a/src/main/resources/data/oc2r/tags/item/devices/card.json
+++ b/src/main/resources/data/oc2r/tags/item/devices/card.json
@@ -4,6 +4,7 @@
     "oc2r:network_interface_card",
     "oc2r:file_import_export_card",
     "oc2r:sound_card",
-    "oc2r:network_tunnel_card"
+    "oc2r:network_tunnel_card",
+    "oc2r:internet_card"
   ]
 }


### PR DESCRIPTION
* Don't try to try to register for render events on a server, this fixes a crash on load for dedicated servers
* Give the internet card it's tags back, apparently it was never added to the datagen so running datagen wiped it's tags
* Give free Minux flash with the computer/robot recipe, this was another casualty from datagen since it was originally added manually