### PR TITLE
Return the key name instead of the registry name (1.20.1)

### DIFF
--- a/src/main/java/li/cil/oc2/common/bus/AbstractBlockDeviceBusElement.java
+++ b/src/main/java/li/cil/oc2/common/bus/AbstractBlockDeviceBusElement.java
@@ -217,6 +217,14 @@ public abstract class AbstractBlockDeviceBusElement extends AbstractGroupingDevi
         }
 
         @Override
+        public Optional<String> getLegacyDeviceDataKey() {
+            if (dataKey != null) {
+                return Optional.of("oc2r:block_device_provider");
+            }
+            return Optional.empty();
+        }
+
+        @Override
         public OptionalInt getDeviceEnergyConsumption() {
             return deviceInfo.isPresent() ? OptionalInt.of(deviceInfo.get().getEnergyConsumption()) : OptionalInt.empty();
         }

--- a/src/main/java/li/cil/oc2/common/bus/AbstractGroupingDeviceBusElement.java
+++ b/src/main/java/li/cil/oc2/common/bus/AbstractGroupingDeviceBusElement.java
@@ -6,9 +6,12 @@ import li.cil.oc2.api.bus.device.Device;
 import li.cil.oc2.common.util.NBTTagIds;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.Tag;
 
 import javax.annotation.Nullable;
 import java.util.*;
+
+import static li.cil.oc2.common.util.OptionalUtils.instanceOf;
 
 public abstract class AbstractGroupingDeviceBusElement<TEntry extends AbstractGroupingDeviceBusElement.Entry, TQuery> extends AbstractDeviceBusElement {
     private static final String GROUPS_TAG_NAME = "groups";
@@ -24,6 +27,7 @@ public abstract class AbstractGroupingDeviceBusElement<TEntry extends AbstractGr
 
     protected interface Entry {
         Optional<String> getDeviceDataKey();
+        Optional<String> getLegacyDeviceDataKey();
 
         OptionalInt getDeviceEnergyConsumption();
 
@@ -92,11 +96,14 @@ public abstract class AbstractGroupingDeviceBusElement<TEntry extends AbstractGr
             // Immediately load data into devices, if we already have some.
             for (final TEntry entry : groups.get(i)) {
                 final CompoundTag devicesTag = groupData[i];
-                entry.getDeviceDataKey().ifPresent(key -> {
-                    if (devicesTag.contains(key, NBTTagIds.TAG_COMPOUND)) {
-                        entry.getDevice().deserializeNBT(devicesTag.getCompound(key));
-                    }
-                });
+                entry.getDeviceDataKey().map(devicesTag::get)
+                    .or(() ->
+                        // Older versions of the mod used a different id that often collided between devices during save
+                        // Try loading from that if we can't load normally
+                        entry.getLegacyDeviceDataKey().map(devicesTag::get)
+                    )
+                    .flatMap(instanceOf(CompoundTag.class))
+                    .ifPresent(deviceTag -> entry.getDevice().deserializeNBT(deviceTag));
             }
         }
     }
@@ -197,6 +204,12 @@ public abstract class AbstractGroupingDeviceBusElement<TEntry extends AbstractGr
                     entry.getDevice().deserializeNBT(devicesTag.getCompound(key));
                 } else {
                     devicesTag.remove(key);
+                    // Older versions of the mod used a different id that often collided between devices during save
+                    // Try loading from that if we can't load normally
+                    entry.getLegacyDeviceDataKey()
+                        .map(devicesTag::get)
+                        .flatMap(instanceOf(CompoundTag.class))
+                        .ifPresent(deviceTag -> entry.getDevice().deserializeNBT(deviceTag));
                 }
             });
         }

--- a/src/main/java/li/cil/oc2/common/bus/AbstractItemDeviceBusElement.java
+++ b/src/main/java/li/cil/oc2/common/bus/AbstractItemDeviceBusElement.java
@@ -20,6 +20,7 @@ import net.minecraftforge.registries.IForgeRegistry;
 import javax.annotation.Nullable;
 import java.util.*;
 
+import static li.cil.oc2.common.util.OptionalUtils.instanceOf;
 import static li.cil.oc2.common.util.RegistryUtils.optionalKey;
 
 public abstract class AbstractItemDeviceBusElement extends AbstractGroupingDeviceBusElement<AbstractItemDeviceBusElement.ItemEntry, ItemDeviceQuery> {
@@ -112,11 +113,14 @@ public abstract class AbstractItemDeviceBusElement extends AbstractGroupingDevic
         final CompoundTag exportedTag = ItemDeviceUtils.getItemDeviceData(query.getItemStack());
         if (!exportedTag.isEmpty()) {
             for (final ItemEntry entry : entries) {
-                entry.getDeviceDataKey().ifPresent(key -> {
-                    if (exportedTag.contains(key, NBTTagIds.TAG_COMPOUND)) {
-                        entry.deviceInfo.device.importFromItemStack(exportedTag.getCompound(key));
-                    }
-                });
+                entry.getDeviceDataKey().map(exportedTag::get)
+                    .or(() ->
+                        // Older versions of the mod used a different id that often collided between devices during save
+                        // Try loading from that if we can't load normally
+                        entry.getLegacyDeviceDataKey().map(exportedTag::get)
+                    )
+                    .flatMap(instanceOf(CompoundTag.class))
+                    .ifPresent(deviceTag -> entry.deviceInfo.device.importFromItemStack(deviceTag));
             }
         }
     }
@@ -148,6 +152,14 @@ public abstract class AbstractItemDeviceBusElement extends AbstractGroupingDevic
         @Override
         public Optional<String> getDeviceDataKey() {
             return optionalKey(deviceInfo.provider);
+        }
+
+        @Override
+        public Optional<String> getLegacyDeviceDataKey() {
+            if (deviceInfo.provider != null) {
+                return Optional.of("oc2r:item_device_provider");
+            }
+            return Optional.empty();
         }
 
         @Override

--- a/src/main/java/li/cil/oc2/common/util/OptionalUtils.java
+++ b/src/main/java/li/cil/oc2/common/util/OptionalUtils.java
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: MIT */
+
+package li.cil.oc2.common.util;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+public final class OptionalUtils {
+    public static <T, C> Function<T, Optional<C>> instanceOf(final Class<C> type) {
+        return (t) -> {
+            if (type.isInstance(t)) {
+                //noinspection unchecked
+                return Optional.of((C) t);
+            } else {
+                return Optional.empty();
+            }
+        };
+    }
+}

--- a/src/main/java/li/cil/oc2/common/util/RegistryUtils.java
+++ b/src/main/java/li/cil/oc2/common/util/RegistryUtils.java
@@ -9,6 +9,7 @@ import li.cil.oc2.api.bus.device.provider.ItemDeviceProvider;
 import li.cil.oc2.common.bus.device.provider.ProviderRegistry;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.IForgeRegistry;
@@ -70,18 +71,18 @@ public abstract class RegistryUtils {
         if(registryEntry == null) {
             return Optional.empty();
         }
-        String providerName = null;
-        if (BlockDeviceProvider.class.isAssignableFrom(registryEntry.getClass())) {
-            providerName = ProviderRegistry.BLOCK_DEVICE_PROVIDER_REGISTRY.get().getRegistryName().toString();
-        } else if (ItemDeviceProvider.class.isAssignableFrom(registryEntry.getClass())) {
-            providerName = ProviderRegistry.ITEM_DEVICE_PROVIDER_REGISTRY.get().getRegistryName().toString();
+        ResourceLocation providerKey = null;
+        if (registryEntry instanceof final BlockDeviceProvider blockDeviceProvider) {
+            providerKey = ProviderRegistry.BLOCK_DEVICE_PROVIDER_REGISTRY.get().getKey(blockDeviceProvider);
+        } else if (registryEntry instanceof final ItemDeviceProvider itemDeviceProvider) {
+            providerKey = ProviderRegistry.ITEM_DEVICE_PROVIDER_REGISTRY.get().getKey(itemDeviceProvider);
         }
 
-        if(providerName == null) {
+        if (providerKey == null) {
             return Optional.empty();
         }
 
-        return Optional.of(providerName);
+        return Optional.of(providerKey.toString());
     }
 
     private RegistryUtils() {


### PR DESCRIPTION
This also aligns the output of optionalKey with the input expected by AbstractGroupingDeviceBusElement::onEntryRemoved implementations, which must have been silently broken

Fixes #108