### PR TITLE
Events support: Java API

### DIFF
--- a/src/main/java/li/cil/oc2/api/README.md
+++ b/src/main/java/li/cil/oc2/api/README.md
@@ -91,9 +91,11 @@ the built-in `RedstoneInterfaceBlockEntity` device.
 - If subscriptions are used on or before OC2R version 2.2.12, they can cause a server crash if too many messages are
   sent at once. To be safe, do not send any event in the same tick as another message, or depend on a later minimum
   version of OC2R.
-- Right now, if a lot of messages are sent and the VM does not listen for them, some may be dropped, and there is no
-  indication to the device or VM when this happens. You cannot depend on the events being reliably delivered, and must
-  use some other communication channel if reliability is a requirement.
+- Right now, if a lot of messages are sent and the VM does not listen for them, some may be dropped; in theory the VM
+  can detect this, but none of the existing libraries do (see next point). You cannot depend on the events being
+  reliably delivered, and must use some other communication channel if reliability is a requirement.  A method call
+  should not have this issue unless the results and all the (subscribed to) events in that tick put together are more
+  than 4 KiB, though be aware that if the method call causes a state change, that might itself cause some events.
 - The on-the-"wire" event and subscription format is probably stable, but the VM's userspace python and lua libraries do
   not easily support them yet, and often silently discard events when expecting a different sort of message. Better
   support is actively being worked on.

--- a/src/main/java/li/cil/oc2/api/README.md
+++ b/src/main/java/li/cil/oc2/api/README.md
@@ -77,12 +77,26 @@ This can be useful for various things. For example:
     - Close and delete the file in `unmount()`.
     - Close the file in `suspend()`.
 
-### No Active Back-channel
+### Subscriptions and Events
 
-Unlike some other computer mods (e.g. OpenComputers and ComputerCraft), there is no *active* back-channel in the
-`RPCDevice` API. In other words, it is not possible for `RPCDevices` to raise events in the virtual machines. The only
-way to provide data to the virtual machines is as values returned from exposed methods. Programs running in the virtual
-machines will always have to poll for changed data.
+The `RPCDevice` API also lets devices raise events in the virtual machine, by implementing the `RPCEventSource`
+interface.  If using `ObjectDevice`, it will automatically notice if the wrapped object implements `RPCEventSource`; if
+implementing `RPCDevice` directly you can either implement `RPCEventSource` on the same type, or override the
+`asEventSource` method to return the actual event source. The VM will then be able to subscribe to events from the
+device, which can be sent by calling `postEvent` on the `IEventSink` passed to `subscribe`. An example of this is
+the built-in `RedstoneInterfaceBlockEntity` device.
+
+#### Note: This is mostly a new feature and there are several caveats to keep in mind when using it.
+
+- If subscriptions are used on or before OC2R version 2.2.12, they can cause a server crash if too many messages are
+  sent at once. To be safe, do not send any event in the same tick as another message, or depend on a later minimum
+  version of OC2R.
+- Right now, if a lot of messages are sent and the VM does not listen for them, some may be dropped, and there is no
+  indication to the device or VM when this happens. You cannot depend on the events being reliably delivered, and must
+  use some other communication channel if reliability is a requirement.
+- The on-the-"wire" event and subscription format is probably stable, but the VM's userspace python and lua libraries do
+  not easily support them yet, and often silently discard events when expecting a different sort of message. Better
+  support is actively being worked on.
 
 ## The `BlockDeviceProvider` and `ItemDeviceProvider`
 

--- a/src/main/java/li/cil/oc2/api/bus/device/object/ObjectDevice.java
+++ b/src/main/java/li/cil/oc2/api/bus/device/object/ObjectDevice.java
@@ -84,6 +84,7 @@ public final class ObjectDevice implements RPCDevice, ItemDevice {
     }
 
     ///////////////////////////////////////////////////////////////////
+    @Override
     public RPCEventSource asEventSource() {
         if (object instanceof RPCEventSource res) {
             return res;

--- a/src/main/java/li/cil/oc2/api/bus/device/rpc/IEventSink.java
+++ b/src/main/java/li/cil/oc2/api/bus/device/rpc/IEventSink.java
@@ -1,7 +1,6 @@
 /* SPDX-License-Identifier: MIT */
 
 package li.cil.oc2.api.bus.device.rpc;
-import com.google.gson.JsonElement;
 import java.util.UUID;
 
 /**
@@ -10,5 +9,11 @@ import java.util.UUID;
  */
 
 public interface IEventSink {
-    void postEvent(UUID sourceid, JsonElement msg);
+    /**
+     * Hand a message to the event sink to process
+     *
+     * @param sourceid The UUID of the originator, usually given by {@link RPCEventSource#subscribe(IEventSink, UUID)}
+     * @param msg The message. Should be serializable with gson
+     */
+    void postEvent(UUID sourceid, Object msg);
 }

--- a/src/main/java/li/cil/oc2/api/bus/device/rpc/RPCDevice.java
+++ b/src/main/java/li/cil/oc2/api/bus/device/rpc/RPCDevice.java
@@ -8,6 +8,8 @@ import li.cil.oc2.api.bus.device.object.ObjectDevice;
 
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 /**
  * Provides an interface for an RPC device, describing the methods that can be
  * called on it and the type names it can be detected by/is compatible with.
@@ -71,6 +73,25 @@ public interface RPCDevice extends Device {
      * @return the list of method groups.
      */
     List<RPCMethodGroup> getMethodGroups();
+
+    /**
+     * Get an {@link RPCEventSource} that handles events for this device, if any
+     *
+     * By default, returns {@code this} if it's an event source, but can be overriden if the event source and the device
+     * are different objects.
+     *
+     * @return An {@link RPCEventSource} that can be used for subscription and unsubscription, or {@code null} if
+     * subscriptions are not supported.
+     */
+    @Nullable
+    default RPCEventSource asEventSource() {
+        if (this instanceof RPCEventSource res) {
+            return res;
+        }
+        else {
+            return null;
+        }
+    }
 
     /**
      * Called to start this device.

--- a/src/main/java/li/cil/oc2/api/bus/device/rpc/RPCEventSource.java
+++ b/src/main/java/li/cil/oc2/api/bus/device/rpc/RPCEventSource.java
@@ -5,10 +5,11 @@ package li.cil.oc2.api.bus.device.rpc;
 import java.util.*;
 
 /**
- * Provides an interface for an RPC event source. Blocks which whish to provide
- * push notifications via the /dev/hvc0 serial devices should implement this.
+ * Provides an interface for an RPC event source. Blocks which wish to provide
+ * push notifications via the RPC bus serial device should implement this.
  * It is generally recommended to *also* provide documentation and a list of
- * events by implementing DocumentedDevice and providing a listEvents() callback
+ * events by implementing {@link li.cil.oc2.api.bus.device.object.DocumentedDevice
+ * DocumentedDevice} and providing a {@code listEvents()} callback
  * <p>
  */
 public interface RPCEventSource {

--- a/src/main/java/li/cil/oc2/common/bus/RPCDeviceBusAdapter.java
+++ b/src/main/java/li/cil/oc2/common/bus/RPCDeviceBusAdapter.java
@@ -58,6 +58,7 @@ public final class RPCDeviceBusAdapter implements Steppable, IEventSink {
     @Serialized private final ByteBuffer transmitBuffer; // for data written to device by VM
     @Serialized private ByteBuffer receiveBuffer; // for data written by device to VM
     @Serialized private MethodInvocation synchronizedInvocation; // pending main thread invocation
+    @Serialized private volatile long sequenceNumber = 0;
 
     ///////////////////////////////////////////////////////////////////
 
@@ -113,6 +114,7 @@ public final class RPCDeviceBusAdapter implements Steppable, IEventSink {
         transmitBuffer.clear();
         receiveBuffer.clear();
         synchronizedInvocation = null;
+        sequenceNumber = 0;
     }
 
     public void pause() {
@@ -483,10 +485,11 @@ public final class RPCDeviceBusAdapter implements Steppable, IEventSink {
     }
 
     private void writeMessage(final String type, @Nullable final Object data) {
-        final String json = gson.toJson(new Message(type, data));
-        final byte[] bytes = json.getBytes();
-        final int messageLength = bytes.length + MESSAGE_DELIMITER.length * 2;
+        // Start synchronization here to also include sequenceNumber increment
         synchronized (receiveLock) {
+            final String json = gson.toJson(new Message(type, data, sequenceNumber++));
+            final byte[] bytes = json.getBytes();
+            final int messageLength = bytes.length + MESSAGE_DELIMITER.length * 2;
             if (receiveBuffer.remaining() < messageLength) {
                 // Decide whether to resize or not
                 // The current heuristic is to resize for a large message (because
@@ -500,7 +503,8 @@ public final class RPCDeviceBusAdapter implements Steppable, IEventSink {
                     reallocate ? "reallocating" : "ignoring");
 
                 if (!reallocate) {
-                    // Note: There is nothing that indicates to either the VM or the peripheral that a message was eaten
+                    // Return without writing anything.  We already incremented sequenceNumber, so the VM can know
+                    // something was missed when it reads the next message actually present.
                     return;
                 }
 
@@ -540,7 +544,7 @@ public final class RPCDeviceBusAdapter implements Steppable, IEventSink {
 
     public record EmptyMethodGroup(String name) { }
 
-    public record Message(String type, @Nullable Object data) {
+    public record Message(String type, @Nullable Object data, long seq) {
         // Device -> VM
         public static final String MESSAGE_TYPE_LIST = "list";
         public static final String MESSAGE_TYPE_METHODS = "methods";

--- a/src/main/java/li/cil/oc2/common/bus/RPCDeviceBusAdapter.java
+++ b/src/main/java/li/cil/oc2/common/bus/RPCDeviceBusAdapter.java
@@ -308,7 +308,21 @@ public final class RPCDeviceBusAdapter implements Steppable, IEventSink {
     }
 
     private void processMessage(final byte[] messageData) {
-        if (new String(messageData).trim().isEmpty()) {
+        // HACK: Linux thinks the RPC bus is a TTY, and when all file descriptors to it are closed and then one is
+        // opened again, the kernel resets the termios attributes and *turns on echo*. This sends a bunch of mangled
+        // garbage back down the bus to end up here. Part of the mangling is replacing control characters, including
+        // replacing the default message delimiter with "^@", so we can try to detect it. This doesn't work in crmode
+        // and it's a bit of a hack to try to catch here
+        //
+        // Medium term solution: keep a file descriptor open on Linux all the time, so the `stty` stuff only needs to be
+        // done once and echo doesn't turn back on.  Also make a human-readable symlink from /dev/oc2r/rpc to /dev/hvc0,
+        // both because of the benefit of being human-readable (see also: /dev/disk/by-label with udev), and to ease the
+        // transition for the longer-term solution.
+        // Longer-term solution: Add an option to VirtIOConsoleDevice to present as a non-tty port; I have a proof of
+        // concept for that but it needs more work.  This would move the bus to /dev/vport0p0, but the symlink can help
+        // ease the transition.
+        String messageString = new String(messageData).trim();
+        if (messageString.isEmpty() || messageString.startsWith("^@")) {
             return;
         }
 

--- a/src/main/java/li/cil/oc2/common/bus/RPCDeviceBusAdapter.java
+++ b/src/main/java/li/cil/oc2/common/bus/RPCDeviceBusAdapter.java
@@ -16,7 +16,6 @@ import li.cil.oc2.common.bus.device.rpc.RPCMethodParameterTypeAdapters;
 import li.cil.oc2.common.serialization.gson.*;
 import li.cil.sedna.api.device.Steppable;
 import li.cil.sedna.api.device.serial.SerialDevice;
-import li.cil.oc2.api.bus.device.object.*;
 import javax.annotation.Nullable;
 
 import org.apache.logging.log4j.LogManager;
@@ -38,6 +37,7 @@ public final class RPCDeviceBusAdapter implements Steppable, IEventSink {
     public static final String ERROR_UNKNOWN_DEVICE = "unknown device";
     public static final String ERROR_UNKNOWN_METHOD = "unknown method";
     public static final String ERROR_INVALID_PARAMETER_SIGNATURE = "invalid parameter signature";
+    public static final String ERROR_SUBSCRIPTIONS_NOT_SUPPORTED = "device does not support subscriptions";
 
     ///////////////////////////////////////////////////////////////////
 
@@ -171,10 +171,10 @@ public final class RPCDeviceBusAdapter implements Steppable, IEventSink {
         devicesByIdentifier.forEach((identifier, devices) -> {
             final RPCDeviceList device = new RPCDeviceList(devices);
 
-            // If there are no methods we have either no devices at all, or all synthetic
-            // devices, i.e. devices that only contribute type names, but have no methods
-            // to call. We do not expose these to avoid cluttering the device list.
-            if (device.getMethodGroups().isEmpty()) {
+            // If there are no methods or events we have either no devices at all, or all
+            // synthetic devices, i.e. devices that only contribute type names, but have
+            // no functionality. We do not expose these to avoid cluttering the device list.
+            if (device.getMethodGroups().isEmpty() && device.asEventSource() == null) {
                 return;
             }
 
@@ -361,44 +361,34 @@ public final class RPCDeviceBusAdapter implements Steppable, IEventSink {
 
     private void subscribe(final UUID deviceId) {
         RPCDeviceList devices = devicesById.get(deviceId);
-        if (devices != null) {
-            for (RPCDevice device : devices.getDevices()) {
-                if (device instanceof ObjectDevice od) {
-                    RPCEventSource res = od.asEventSource();
-                    if (res != null) {
-                        res.subscribe(this, deviceId);
-                        subscriptions.add(res);
-                        return;
-                    }
-                }
-                if (device instanceof RPCEventSource res) {
-                    res.subscribe(this, deviceId);
-                    subscriptions.add(res);
-                    return;
-                }
-            }
-            writeError("device does not support subscriptions");
+        if (devices == null) {
+            writeError(ERROR_UNKNOWN_DEVICE);
+            return;
         }
-        else {
-            writeError("unknown device");
+        RPCEventSource res = devices.asEventSource();
+        if (res == null) {
+            writeError(ERROR_SUBSCRIPTIONS_NOT_SUPPORTED);
         }
+
+        res.subscribe(this, deviceId);
+        subscriptions.add(res);
+        writeMessage(Message.MESSAGE_TYPE_SUBSCRIBE, null);
     }
+
     private void unsubscribe(final UUID deviceId) {
         RPCDeviceList devices = devicesById.get(deviceId);
-        if (devices != null) {
-            for (RPCDevice device : devices.getDevices()) {
-                if (device instanceof RPCEventSource res) {
-                    res.unsubscribe(this);
-                    subscriptions.remove(res);
-                }
-                else {
-                    writeError("device does not support subscriptions");
-                }
-            }
+        if (devices == null) {
+            writeError(ERROR_UNKNOWN_DEVICE);
+            return;
         }
-        else {
-            writeError("unknown device");
+        RPCEventSource res = devices.asEventSource();
+        if (res == null) {
+            writeError(ERROR_SUBSCRIPTIONS_NOT_SUPPORTED);
         }
+
+        res.unsubscribe(this);
+        subscriptions.remove(res);
+        writeMessage(Message.MESSAGE_TYPE_UNSUBSCRIBE, null);
     }
 
     private void processMethodInvocation(final MethodInvocation methodInvocation, final boolean isMainThread) {

--- a/src/main/java/li/cil/oc2/common/bus/RPCDeviceBusAdapter.java
+++ b/src/main/java/li/cil/oc2/common/bus/RPCDeviceBusAdapter.java
@@ -18,6 +18,9 @@ import li.cil.sedna.api.device.Steppable;
 import li.cil.sedna.api.device.serial.SerialDevice;
 import li.cil.oc2.api.bus.device.object.*;
 import javax.annotation.Nullable;
+
+import org.apache.logging.log4j.LogManager;
+
 import java.io.ByteArrayInputStream;
 import java.io.InputStreamReader;
 import java.nio.ByteBuffer;
@@ -46,6 +49,7 @@ public final class RPCDeviceBusAdapter implements Steppable, IEventSink {
     private final Set<RPCDeviceList> unmountedDevices = new HashSet<>();
     private final Set<RPCDeviceList> mountedDevices = new HashSet<>();
     private final Lock pauseLock = new ReentrantLock();
+    private final Object receiveLock = new Object(); // Lock object for receive buffer
     private boolean isPaused;
     private boolean crmode = false;
     private final ArrayList<RPCEventSource> subscriptions = new ArrayList<>();
@@ -65,6 +69,7 @@ public final class RPCDeviceBusAdapter implements Steppable, IEventSink {
     public RPCDeviceBusAdapter(final SerialDevice serialDevice, final int maxMessageSize) {
         this.serialDevice = serialDevice;
         this.transmitBuffer = ByteBuffer.allocate(maxMessageSize);
+        this.receiveBuffer = ByteBuffer.allocate(maxMessageSize);
         this.gson = RPCMethodParameterTypeAdapters.beginBuildGson()
             .registerTypeAdapter(byte[].class, new UnsignedByteArrayJsonSerializer())
             .registerTypeAdapter(MethodInvocation.class, new MethodInvocationJsonDeserializer())
@@ -107,7 +112,7 @@ public final class RPCDeviceBusAdapter implements Steppable, IEventSink {
 
     public void reset() {
         transmitBuffer.clear();
-        receiveBuffer = null;
+        receiveBuffer.clear();
         synchronizedInvocation = null;
     }
 
@@ -122,6 +127,13 @@ public final class RPCDeviceBusAdapter implements Steppable, IEventSink {
     }
 
     public void resume(final DeviceBusController controller, final boolean didDevicesChange) {
+        // Fix for upgrade from pre-event-support.  Ideally this would be done on deserialization, but Ceres doesn't
+        // have a hook for that, and this should at least run before the buffer is needed.
+        if (receiveBuffer == null) {
+            // Default receive buffer size is the same as transmitBuffer capacity
+            receiveBuffer = ByteBuffer.allocate(transmitBuffer.capacity());
+        }
+
         isPaused = false;
 
         if (!didDevicesChange) {
@@ -210,7 +222,8 @@ public final class RPCDeviceBusAdapter implements Steppable, IEventSink {
 
             // This is also used to prevent thread from processing messages, so only
             // reset this when we're done. Otherwise, we may get a race-condition when
-            // writing back data.
+            // writing back data, which would not cause interleaved messages but might
+            // confuse which results go with which method call.
             synchronizedInvocation = null;
         }
     }
@@ -242,12 +255,24 @@ public final class RPCDeviceBusAdapter implements Steppable, IEventSink {
     }
 
     private void readFromDevice() {
-        // Only ever allow one pending message to avoid giving the VM the
-        // power of uncontrollably inflating memory usage. Basically any
-        // method of limiting the write queue size would work, but this is
-        // the most simple and easy to maintain one I could think of.
+        // Early return if we don't want to handle a new message.
+        // 1. Make sure receiveBuffer is empty so we can almost certainly write results back (not a guarantee if events
+        // are posted at the wrong time, especially if a device posts events while handling a method, but should be fine
+        // if there is no misbehaving device).
+        // 2. Make sure there is no pending synchronized method invocation so we only need to deal with one at once and
+        // we can be sure we respond to methods in the order called.
+        // Note that a synchronized method invocation is much more likely to have unrelated events post between the call
+        // and the results.
+        synchronized (receiveLock) {
+            if (receiveBuffer.position() != 0 || synchronizedInvocation != null) {
+                return;
+            }
+        }
+
         int value;
-        while (receiveBuffer == null && synchronizedInvocation == null && (value = serialDevice.read()) >= 0) {
+        // Only ever read one message at a time.  The first early return check *will* be invalidated by processing a
+        // message and the second also could be
+        while ((value = serialDevice.read()) >= 0) {
             if (value == 0 || value == 13) {
                 this.crmode = value == 13;
                 if (transmitBuffer.limit() > 0) {
@@ -271,19 +296,16 @@ public final class RPCDeviceBusAdapter implements Steppable, IEventSink {
     }
 
     private void writeToDevice() {
-        if (receiveBuffer == null) {
-            return;
-        }
+        synchronized (receiveLock) {
+            receiveBuffer.flip();
 
-        while (receiveBuffer.hasRemaining() && serialDevice.canPutByte()) {
-            serialDevice.putByte(receiveBuffer.get());
-        }
+            while (receiveBuffer.hasRemaining() && serialDevice.canPutByte()) {
+                serialDevice.putByte(receiveBuffer.get());
+            }
 
+            receiveBuffer.compact();
+        }
         serialDevice.flush();
-
-        if (!receiveBuffer.hasRemaining()) {
-            receiveBuffer = null;
-        }
     }
 
     private void processMessage(final byte[] messageData) {
@@ -458,35 +480,55 @@ public final class RPCDeviceBusAdapter implements Steppable, IEventSink {
     }
 
     private void writeMessage(final String type, @Nullable final Object data) {
-        if (receiveBuffer != null) throw new IllegalStateException();
         final String json = gson.toJson(new Message(type, data));
         final byte[] bytes = json.getBytes();
-        final ByteBuffer receiveBuffer = ByteBuffer.allocate(bytes.length + MESSAGE_DELIMITER.length * 2);
+        final int messageLength = bytes.length + MESSAGE_DELIMITER.length * 2;
+        synchronized (receiveLock) {
+            if (receiveBuffer.remaining() < messageLength) {
+                // Decide whether to resize or not
+                // The current heuristic is to resize for a large message (because
+                // that is probably intended by a mod author) and not for many small
+                // messages (because a computer user could use unlimited memory that
+                // way).
+                boolean reallocate = (receiveBuffer.capacity() <= messageLength);
+                LogManager.getLogger().warn(
+                    "Attempted to send {} message without enough space (size {}, remaining {}), {}",
+                    type, messageLength, receiveBuffer.remaining(),
+                    reallocate ? "reallocating" : "ignoring");
 
-        // In case we went through a reset and the VM was in the middle of reading
-        // a message we inject a delimiter up front to cause the truncated message
-        // to be discarded.
-        if (this.crmode) {
-            receiveBuffer.put(MESSAGE_DELIMITER2);
-        }
-        else {
-            receiveBuffer.put(MESSAGE_DELIMITER);
-        }
+                if (!reallocate) {
+                    // Note: There is nothing that indicates to either the VM or the peripheral that a message was eaten
+                    return;
+                }
 
-        receiveBuffer.put(bytes);
+                ByteBuffer newReceiveBuffer = ByteBuffer.allocate(messageLength * 2);
+                newReceiveBuffer.put(receiveBuffer.flip());
+                receiveBuffer = newReceiveBuffer;
+                assert(messageLength < receiveBuffer.remaining());
+            }
 
-        // We follow up each message with a delimiter, too, so the VM knows when the
-        // message has been completed. This will lead to two delimiters between most
-        // messages. The VM is expected to ignore such "empty" messages.
-        if (this.crmode) {
-            receiveBuffer.put(MESSAGE_DELIMITER2);
-        }
-        else {
-            receiveBuffer.put(MESSAGE_DELIMITER);
-        }
+            // In case we went through a reset and the VM was in the middle of reading
+            // a message we inject a delimiter up front to cause the truncated message
+            // to be discarded.
+            if (this.crmode) {
+                receiveBuffer.put(MESSAGE_DELIMITER2);
+            }
+            else {
+                receiveBuffer.put(MESSAGE_DELIMITER);
+            }
 
-        receiveBuffer.flip();
-        this.receiveBuffer = receiveBuffer;
+            receiveBuffer.put(bytes);
+
+            // We follow up each message with a delimiter, too, so the VM knows when the
+            // message has been completed. This will lead to two delimiters between most
+            // messages. The VM is expected to ignore such "empty" messages.
+            if (this.crmode) {
+                receiveBuffer.put(MESSAGE_DELIMITER2);
+            }
+            else {
+                receiveBuffer.put(MESSAGE_DELIMITER);
+            }
+        }
     }
 
     ///////////////////////////////////////////////////////////////////

--- a/src/main/java/li/cil/oc2/common/bus/RPCDeviceBusAdapter.java
+++ b/src/main/java/li/cil/oc2/common/bus/RPCDeviceBusAdapter.java
@@ -4,7 +4,6 @@ package li.cil.oc2.common.bus;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
 import li.cil.ceres.api.Serialized;
 import li.cil.oc2.api.bus.DeviceBusController;
 import li.cil.oc2.api.bus.device.Device;
@@ -355,7 +354,7 @@ public final class RPCDeviceBusAdapter implements Steppable, IEventSink {
     }
 
     @Override
-    public void postEvent(UUID deviceid, JsonElement msg) {
+    public void postEvent(UUID deviceid, Object msg) {
         writeMessage(Message.MESSAGE_TYPE_EVENT, new Object[]{deviceid, msg});
     }
 

--- a/src/main/java/li/cil/oc2/common/bus/device/rpc/RPCDeviceList.java
+++ b/src/main/java/li/cil/oc2/common/bus/device/rpc/RPCDeviceList.java
@@ -2,13 +2,17 @@
 
 package li.cil.oc2.common.bus.device.rpc;
 
+import li.cil.oc2.api.bus.device.rpc.IEventSink;
 import li.cil.oc2.api.bus.device.rpc.RPCDevice;
+import li.cil.oc2.api.bus.device.rpc.RPCEventSource;
 import li.cil.oc2.api.bus.device.rpc.RPCMethodGroup;
 import net.minecraft.nbt.CompoundTag;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 public record RPCDeviceList(ArrayList<RPCDevice> devices) implements RPCDevice {
@@ -66,5 +70,30 @@ public record RPCDeviceList(ArrayList<RPCDevice> devices) implements RPCDevice {
     @Override
     public void deserializeNBT(final CompoundTag tag) {
         throw new UnsupportedOperationException();
+    }
+
+    private record RPCEventSourceList(List<RPCEventSource> sources) implements RPCEventSource {
+        @Override
+        public void subscribe(IEventSink dba, UUID sourceid) {
+            for (RPCEventSource source : sources) {
+                source.subscribe(dba, sourceid);
+            }
+        }
+
+        @Override
+        public void unsubscribe(IEventSink dba) {
+            for (RPCEventSource source : sources) {
+                source.unsubscribe(dba);
+            }
+        }
+    }
+
+    @Override
+    public RPCEventSource asEventSource() {
+        List<RPCEventSource> sources = devices.stream()
+                .map(RPCDevice::asEventSource)
+                .filter(Objects::nonNull)
+                .toList();
+        return sources.isEmpty() ? null : new RPCEventSourceList(sources);
     }
 }

--- a/src/main/java/li/cil/oc2/common/serialization/gson/MessageJsonDeserializer.java
+++ b/src/main/java/li/cil/oc2/common/serialization/gson/MessageJsonDeserializer.java
@@ -21,7 +21,8 @@ public final class MessageJsonDeserializer implements JsonDeserializer<RPCDevice
             case RPCDeviceBusAdapter.Message.MESSAGE_TYPE_INVOKE_METHOD -> context.deserialize(jsonObject.getAsJsonObject("data"), RPCDeviceBusAdapter.MethodInvocation.class);
             default -> throw new JsonParseException(RPCDeviceBusAdapter.ERROR_UNKNOWN_MESSAGE_TYPE + messageType);
         };
+        final long messageSequenceNumber = jsonObject.has("seq") ? jsonObject.getAsJsonPrimitive("seq").getAsLong() : -1;
 
-        return new RPCDeviceBusAdapter.Message(messageType, messageData);
+        return new RPCDeviceBusAdapter.Message(messageType, messageData, messageSequenceNumber);
     }
 }


### PR DESCRIPTION
# Description

This is the Java side of my ongoing project to finish the partial support for events and subscriptions thatʼs in the code.

The main problem was that the existing code does not allow more than one message in the queue for the VM to receive, and would raise an exception if there was more than one, which could easily crash the server.  My initial thought was to still have the limit but discard extra messages, but often more than one event at a time is useful (especially with the redstone interface block, given the way that redstone dust has excessive amounts of block updates when it powers down), so I did a more complicated thing instead.

There are a few other problems with the Java side of events that I also fixed: `unsubscribe` didnʼt work with `ObjectDevice`s, the way the RPC bus is hooked up to the VM causes extra garbage the bus didnʼt know how to handle (which I have a hacky fix for and a couple ideas about better fixes which can be implemented separately later), the bus would ignore devices which only have events and not methods, and finally there was a chance messages would be silently dropped if there were too many events.

# Other work
I am also working on making the Python library better (I can maybe work on the Lua library after that but I do not know Lua nearly as well), but that will be a different PR.  The goal is that as long as subscriptions are not being used, everything here stays exactly the same, and the existing library can still work.

My existing Python PR, #122, is for things that make sense even without events, even if most of it is unlikely to come up; the future PR will have things like `Device.subscribe` and `Device.unsubscribe` methods.

I also have plans to improve the redstone interface events in a few ways, but that is also a separate PR; for now it generates many redundant events and the side identification is global for those events even though itʼs local for all the method calls.

The medium-term solution to the echo problem requires adding a program to the Minux `rootfs-overlay` and setting it up to launch at system startup; I have most of the program written but have not finished it.

If the long-term solution to the echo problem is adopted, it will require a change to the Sedna `VirtIOConsoleDevice` class; I have a proof-of-concept change there but it needs work.  It will also require any external projects which assume the location of the bus devices to be updated; with the current hacky solution or the medium-term less-hacky one, projects will only need to be updated if they want to support events.

# Specific things to call out

This changes the on-the-“wire” format in two ways, both of which should be mostly backwards compatible but which should be made explicit:

* All events sent from the bus to the VM now include an extra `seq` field, in addition to `type` and `data`.  This is a `long` which increments for each message, making it easy to see when messages are missed.  Currently no library checks it, of course, but this could be very useful if it comes up.
  - Should be fully backwards-compatible; I expect all existing libraries ignore it by default.  The built-in micropython and lua libraries ignore it in all cases I can find, with both experimentation and checking the code.  The only other implementation I know of is [27factorial/oc2-hlapi](https://github.com/27factorial/oc2-hlapi), which I havenʼt tested but based on reading the code should silently ignore the extra field.  I can check other libraries if anyone is aware of any, but I expect most will also silently ignore unknown fields.
  - The VM can also optionally send a sequence number to the bus, which is parsed and silently ignored if present, and set to -1 and silently ignored if absent.
  - Just in case, I confined this to the last commit; if this is undesired I can easily remove it and leave the version without sequence numbers.
* Both `subscribe` and `unsubscribe` methods from the VM now get a response like every other VM-to-bus message does; previously they only got a response on error.  The success message is an empty message of the same type, which somewhat mirrors the way `list` and `methods` messages work now
  - Should be backwards compatible for anyone who doesnʼt use the existing subscription functionality
  - Will need a small change if anyone does, but given how existing subscriptions tend to crash the game I donʼt expect anyone will mind.

Also, I am not used to Java and may have made bad assumptions, especially around concurrency.  I donʼt *think* I introduced any concurrency issues, but that should be double-checked.  Iʼm particularly unsure about `RPCDeviceBusAdapter::reset`; it looks like that might have had issues already, although I havenʼt caught it acting up, so Iʼm not sure if that is handled properly or if I might have made it worse.