### PR TITLE
[Fix] TCP buffer not flushing without PSH flag

### DIFF
--- a/src/main/java/li/cil/oc2/common/inet/DefaultTransportLayer.java
+++ b/src/main/java/li/cil/oc2/common/inet/DefaultTransportLayer.java
@@ -360,7 +360,9 @@ public final class DefaultTransportLayer implements TransportLayer {
 
     @Override
     public void onStop() {
-        for (final SessionBase session : sessions.values()) {
+        // Avoid concurrent modifications
+        final HashMap<SessionDiscriminator<?>, SessionBase> clone = new HashMap<>(sessions);
+        for (final SessionBase session : clone.values()) {
             session.expire();
             sessionLayer.sendSession(session, null);
             closeSession(session);

--- a/src/main/java/li/cil/oc2/common/inet/StreamSessionImpl.java
+++ b/src/main/java/li/cil/oc2/common/inet/StreamSessionImpl.java
@@ -290,13 +290,13 @@ public class StreamSessionImpl extends SessionBase implements StreamSession {
                     }
                 }
                 session.vmWindow = header.window;
-                if (header.psh) {
-                    // Data to be sent
-                    session.vmSequence += length;
-                    final ByteBuffer sendBuffer = session.sendBuffer;
-                    sendBuffer.compact();
-                    sendBuffer.put(segment);
-                    sendBuffer.flip();
+                // Data to be sent
+                session.vmSequence += length;
+                final ByteBuffer sendBuffer = session.sendBuffer;
+                sendBuffer.compact();
+                sendBuffer.put(segment);
+                sendBuffer.flip();
+                if (header.psh || length > 0) {
                     session.needsAcknowledgment = true;
                 }
                 if (header.fin) {

--- a/src/main/java/li/cil/oc2/common/inet/TcpHeader.java
+++ b/src/main/java/li/cil/oc2/common/inet/TcpHeader.java
@@ -120,7 +120,7 @@ public class TcpHeader {
     }
 
     public boolean isAcceptanceOrRejectionAcknowledged() {
-        return !syn && !urg && ack && !psh && !rst && !fin;
+        return !syn && !urg && ack && !rst && !fin;
     }
 
     public void rejectConnection(final int sequence, final int acknowledgment) {


### PR DESCRIPTION
Fixes fragmented TCP packets, which affects TLS handshake => Fixes HTTPS, yay!

<img width="1487" height="905" alt="image" src="https://github.com/user-attachments/assets/c9ad72a2-e014-4313-829e-b838da8eddcb" />