### PR TITLE
[Feature] Robot enhancements

### DIFF
--- a/src/main/java/li/cil/oc2/common/bus/device/rpc/RPCMethodParameterTypeAdapters.java
+++ b/src/main/java/li/cil/oc2/common/bus/device/rpc/RPCMethodParameterTypeAdapters.java
@@ -4,10 +4,13 @@ package li.cil.oc2.common.bus.device.rpc;
 
 import com.google.gson.GsonBuilder;
 import li.cil.oc2.api.imc.RPCMethodParameterTypeAdapter;
+import li.cil.oc2.common.serialization.gson.BlockStateJsonSerializer;
 import li.cil.oc2.common.serialization.gson.DirectionJsonSerializer;
 import li.cil.oc2.common.serialization.gson.ItemStackJsonSerializer;
 import net.minecraft.core.Direction;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
 
 import java.util.ArrayList;
 
@@ -18,6 +21,7 @@ public final class RPCMethodParameterTypeAdapters {
 
     public static void initialize() {
         addTypeAdapter(ItemStack.class, new ItemStackJsonSerializer());
+        addTypeAdapter(BlockState.class, new BlockStateJsonSerializer());
         addTypeAdapter(Direction.class, new DirectionJsonSerializer());
     }
 

--- a/src/main/java/li/cil/oc2/common/bus/device/rpc/item/BlockOperationsModuleDevice.java
+++ b/src/main/java/li/cil/oc2/common/bus/device/rpc/item/BlockOperationsModuleDevice.java
@@ -47,7 +47,7 @@ import java.util.List;
 public final class BlockOperationsModuleDevice extends AbstractItemRPCDevice {
     private static final String LAST_OPERATION_TAG_NAME = "cooldown";
 
-    private static final int COOLDOWN = TickUtils.toTicks(Duration.ofMillis(250));
+    private static final int COOLDOWN = TickUtils.toTicks(Duration.ofMillis((long) (Config.robotCooldown * 1000)));
 
     ///////////////////////////////////////////////////////////////////
 

--- a/src/main/java/li/cil/oc2/common/bus/device/rpc/item/BlockOperationsModuleDevice.java
+++ b/src/main/java/li/cil/oc2/common/bus/device/rpc/item/BlockOperationsModuleDevice.java
@@ -19,6 +19,7 @@ import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Tier;
@@ -46,7 +47,7 @@ import java.util.List;
 public final class BlockOperationsModuleDevice extends AbstractItemRPCDevice {
     private static final String LAST_OPERATION_TAG_NAME = "cooldown";
 
-    private static final int COOLDOWN = TickUtils.toTicks(Duration.ofSeconds(1));
+    private static final int COOLDOWN = TickUtils.toTicks(Duration.ofMillis(250));
 
     ///////////////////////////////////////////////////////////////////
 
@@ -87,10 +88,9 @@ public final class BlockOperationsModuleDevice extends AbstractItemRPCDevice {
             return false;
         }
 
-        beginCooldown();
-
         final Level level = entity.level();
         if (!(level instanceof final ServerLevel serverLevel)) {
+            beginCooldown();
             return false;
         }
 
@@ -100,9 +100,13 @@ public final class BlockOperationsModuleDevice extends AbstractItemRPCDevice {
         final List<ItemEntity> oldItems = getItemsInRange();
 
         final Direction direction = RobotOperationSide.toGlobal(entity, side);
-        if (!tryHarvestBlock(serverLevel, entity.blockPosition().relative(direction))) {
+        final BlockPos pos = entity.blockPosition().relative(direction);
+        final int cooldown = tryHarvestBlock(serverLevel, pos);
+        if (cooldown < 0) {
+            beginCooldown();
             return false;
         }
+        beginCooldown(cooldown);
 
         final List<ItemEntity> droppedItems = getItemsInRange();
         droppedItems.removeAll(oldItems);
@@ -212,62 +216,77 @@ public final class BlockOperationsModuleDevice extends AbstractItemRPCDevice {
     ///////////////////////////////////////////////////////////////////
 
     private void beginCooldown() {
-        lastOperation = entity.level().getGameTime();
+        beginCooldown(COOLDOWN);
     }
 
-    private boolean isOnCooldown() {
-        return entity.level().getGameTime() - lastOperation < COOLDOWN;
+    private void beginCooldown(int cooldown) {
+        lastOperation = entity.level().getGameTime() + cooldown;
+    }
+
+    @Callback
+    public boolean isOnCooldown() {
+        return getCooldown() > 0;
+    }
+
+    @Callback
+    public int getCooldown() {
+        return (int) (-Math.min(0, entity.level().getGameTime() - lastOperation) / 20.0); // Convert to seconds for convenience
     }
 
     private List<ItemEntity> getItemsInRange() {
         return entity.level().getEntitiesOfClass(ItemEntity.class, entity.getBoundingBox().inflate(2));
     }
 
-    private boolean tryHarvestBlock(final ServerLevel level, final BlockPos blockPos) {
+    private int tryHarvestBlock(final ServerLevel level, final BlockPos blockPos) {
         // This method is based on PlayerInteractionManager::tryHarvestBlock. Simplified for our needs.
         final BlockState blockState = level.getBlockState(blockPos);
         if (blockState.isAir()) {
-            return false;
+            return -1;
         }
 
         final ServerPlayer player = FakePlayerUtils.getFakePlayer(level, entity);
         final int experience = net.minecraftforge.common.ForgeHooks.onBlockBreakEvent(level, GameType.DEFAULT_MODE, player, blockPos);
         if (experience == -1) {
-            return false;
+            return -1;
         }
 
         final BlockEntity blockEntity = level.getBlockEntity(blockPos);
         final Block block = blockState.getBlock();
+        if (block.defaultDestroyTime() < 0) {
+            return -1;
+        }
+
         final boolean isCommandBlock = block instanceof CommandBlock || block instanceof StructureBlock || block instanceof JigsawBlock;
         if (isCommandBlock && !player.canUseGameMasterBlocks()) {
-            return false;
+            return -1;
         }
 
         if (player.blockActionRestricted(level, blockPos, GameType.DEFAULT_MODE)) {
-            return false;
+            return -1;
         }
 
         final Tier toolTier = TierSortingRegistry.byName(Config.blockOperationsModuleToolTier);
         if (toolTier == null || !TierSortingRegistry.isCorrectTierForDrops(toolTier, blockState)) {
-            return false;
+            return -1;
         }
 
         if (!ForgeEventFactory.doPlayerHarvestCheck(player, blockState, true)) {
-            return false;
+            return -1;
         }
 
         if (identity.hurt(1, level.random, null)) {
-            return false;
+            return -1;
         }
 
         if (!blockState.onDestroyedByPlayer(level, blockPos, player, true, level.getFluidState(blockPos))) {
-            return false;
+            return -1;
         }
 
+        final int cooldown = Math.round(block.defaultDestroyTime() * 30 / toolTier.getSpeed());
         block.destroy(level, blockPos, blockState);
         block.playerDestroy(level, player, blockPos, blockState, blockEntity, ItemStack.EMPTY);
 
-        return true;
+        return cooldown;
     }
 
     @Nullable

--- a/src/main/java/li/cil/oc2/common/bus/device/rpc/item/BlockOperationsModuleDevice.java
+++ b/src/main/java/li/cil/oc2/common/bus/device/rpc/item/BlockOperationsModuleDevice.java
@@ -78,6 +78,18 @@ public final class BlockOperationsModuleDevice extends AbstractItemRPCDevice {
     }
 
     @Callback
+    public BlockState getBlock() {
+        return getBlock(null);
+    }
+
+    @Callback
+    public BlockState getBlock(@Parameter("side") @Nullable final RobotOperationSide side) {
+        final Direction direction = RobotOperationSide.toGlobal(entity, side);
+        final BlockPos pos = entity.blockPosition().relative(direction);
+        return entity.level().getBlockState(pos);
+    }
+
+    @Callback
     public boolean excavate() {
         return excavate(null);
     }

--- a/src/main/java/li/cil/oc2/common/bus/device/rpc/item/InventoryOperationsModuleDevice.java
+++ b/src/main/java/li/cil/oc2/common/bus/device/rpc/item/InventoryOperationsModuleDevice.java
@@ -108,7 +108,11 @@ public final class InventoryOperationsModuleDevice extends AbstractItemRPCDevice
 
         if (!stack.isEmpty()) {
             dropped += stack.getCount();
-            entity.spawnAtLocation(stack);
+
+            final BlockPos pos = entity.blockPosition().relative(direction);
+            final ItemEntity itemEntity = new ItemEntity(entity.level(), pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5, stack);
+            itemEntity.setDefaultPickUpDelay();
+            entity.level().addFreshEntity(itemEntity);
         }
 
         return dropped;
@@ -151,7 +155,11 @@ public final class InventoryOperationsModuleDevice extends AbstractItemRPCDevice
 
         if (!stack.isEmpty()) {
             dropped += stack.getCount();
-            entity.spawnAtLocation(stack);
+
+            final BlockPos pos = entity.blockPosition().relative(direction);
+            final ItemEntity itemEntity = new ItemEntity(entity.level(), pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5, stack);
+            itemEntity.setDefaultPickUpDelay();
+            entity.level().addFreshEntity(itemEntity);
         }
 
         return dropped;

--- a/src/main/java/li/cil/oc2/common/config/Config.java
+++ b/src/main/java/li/cil/oc2/common/config/Config.java
@@ -49,6 +49,7 @@ public final class Config {
 
     public static ResourceLocation blockOperationsModuleToolTier = TierSortingRegistry.getName(Tiers.DIAMOND);
     public static long soundCardCoolDownSeconds = 2;
+    public static double robotCooldown = 1.0;
 
     public static UUID fakePlayerUUID = UUID.fromString("e39dd9a7-514f-4a2d-aa5e-b6030621416d");
     public static int projectorAverageMaxBytesPerSecond = 160 * 1024;

--- a/src/main/java/li/cil/oc2/common/config/common/GameplaySpec.java
+++ b/src/main/java/li/cil/oc2/common/config/common/GameplaySpec.java
@@ -8,6 +8,7 @@ import net.minecraftforge.common.TierSortingRegistry;
 public class GameplaySpec {
     public final ForgeConfigSpec.EnumValue<Tiers> blockOperationsModuleToolTier;
     public final ForgeConfigSpec.LongValue soundCardCoolDownSeconds;
+    public final ForgeConfigSpec.DoubleValue robotCooldown;
 
     GameplaySpec(ForgeConfigSpec.Builder builder) {
         blockOperationsModuleToolTier = builder.comment(
@@ -17,10 +18,19 @@ public class GameplaySpec {
         soundCardCoolDownSeconds = builder.comment(
             "The number of seconds between sound card uses, to prevent spam/abuse"
         ).defineInRange("soundCardCoolDownSeconds", 2, 1, Long.MAX_VALUE);
+
+        builder.push("entities");
+
+        robotCooldown = builder.comment(
+            "The number of seconds between actions of the robot"
+        ).defineInRange("robotCooldown", 1.0, 0.05, Double.MAX_VALUE);
+
+        builder.pop();
     }
 
     public void loadValues() {
         Config.blockOperationsModuleToolTier = TierSortingRegistry.getName(blockOperationsModuleToolTier.get());
         Config.soundCardCoolDownSeconds = soundCardCoolDownSeconds.get();
+        Config.robotCooldown = robotCooldown.get();
     }
 }

--- a/src/main/java/li/cil/oc2/common/entity/robot/RobotMovementAction.java
+++ b/src/main/java/li/cil/oc2/common/entity/robot/RobotMovementAction.java
@@ -2,6 +2,7 @@
 
 package li.cil.oc2.common.entity.robot;
 
+import li.cil.oc2.common.config.Config;
 import li.cil.oc2.common.entity.Entities;
 import li.cil.oc2.common.entity.Robot;
 import li.cil.oc2.common.util.NBTTagIds;
@@ -23,7 +24,7 @@ public final class RobotMovementAction extends AbstractRobotAction {
 
     ///////////////////////////////////////////////////////////////////
 
-    private static final float MOVEMENT_SPEED = 1f / TickUtils.toTicks(Duration.ofSeconds(1)); // blocks per tick
+    private static final float MOVEMENT_SPEED = 1f / TickUtils.toTicks(Duration.ofMillis((long) (Config.robotCooldown * 1000))); // blocks per tick
 
     private static final String DIRECTION_TAG_NAME = "direction";
     private static final String ORIGIN_TAG_NAME = "origin";

--- a/src/main/java/li/cil/oc2/common/entity/robot/RobotRotationAction.java
+++ b/src/main/java/li/cil/oc2/common/entity/robot/RobotRotationAction.java
@@ -2,6 +2,7 @@
 
 package li.cil.oc2.common.entity.robot;
 
+import li.cil.oc2.common.config.Config;
 import li.cil.oc2.common.entity.Robot;
 import li.cil.oc2.common.util.NBTTagIds;
 import li.cil.oc2.common.util.NBTUtils;
@@ -18,7 +19,7 @@ public final class RobotRotationAction extends AbstractRobotAction {
 
     ///////////////////////////////////////////////////////////////////
 
-    private static final float ROTATION_SPEED = 90f / TickUtils.toTicks(Duration.ofSeconds(1)); // degrees per tick
+    private static final float ROTATION_SPEED = 90f / TickUtils.toTicks(Duration.ofMillis((long) (Config.robotCooldown * 1000))); // degrees per tick
 
     private static final String DIRECTION_TAG_NAME = "direction";
     private static final String TARGET_TAG_NAME = "start";

--- a/src/main/java/li/cil/oc2/common/serialization/gson/BlockStateJsonSerializer.java
+++ b/src/main/java/li/cil/oc2/common/serialization/gson/BlockStateJsonSerializer.java
@@ -12,9 +12,6 @@ public class BlockStateJsonSerializer implements JsonSerializer<BlockState> {
 
     @Override
     public JsonElement serialize(final BlockState src, final Type typeOfSrc, final JsonSerializationContext context) {
-        if (src.isAir()) {
-            return JsonNull.INSTANCE;
-        }
         JsonObject json = new JsonObject();
         ResourceLocation blockName = ForgeRegistries.BLOCKS.getKey(src.getBlock());
         json.addProperty("block", blockName.toString());

--- a/src/main/java/li/cil/oc2/common/serialization/gson/BlockStateJsonSerializer.java
+++ b/src/main/java/li/cil/oc2/common/serialization/gson/BlockStateJsonSerializer.java
@@ -1,0 +1,29 @@
+package li.cil.oc2.common.serialization.gson;
+
+import com.google.gson.*;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.Property;
+import net.minecraftforge.registries.ForgeRegistries;
+
+import java.lang.reflect.Type;
+
+public class BlockStateJsonSerializer implements JsonSerializer<BlockState> {
+
+    @Override
+    public JsonElement serialize(final BlockState src, final Type typeOfSrc, final JsonSerializationContext context) {
+        if (src.isAir()) {
+            return JsonNull.INSTANCE;
+        }
+        JsonObject json = new JsonObject();
+        ResourceLocation blockName = ForgeRegistries.BLOCKS.getKey(src.getBlock());
+        json.addProperty("block", blockName.toString());
+
+        JsonObject props = new JsonObject();
+        for (Property<?> property : src.getProperties()) {
+            props.addProperty(property.getName(), src.getValue(property).toString());
+        }
+        json.add("properties", props);
+        return json;
+    }
+}


### PR DESCRIPTION
- Added config for robot cooldowns (Was hardcoded 1 second)
- Dynamic cooldowns on different block breaks (Avoids spam of obsidian breaking, speeds up dirt excavation, etc.)
- Added block_operations#getBlock([side]) which allows the robot to scan nearby blocks
- Fixed item drop logic when spawning item in-world, now follows specified side
- Fixed ability to break bedrock via robot (It shouldn't be a thing, right?)