### PR TITLE
Fix RPC method return value documentation

### DIFF
--- a/src/main/java/li/cil/oc2/api/bus/device/object/Callbacks.java
+++ b/src/main/java/li/cil/oc2/api/bus/device/object/Callbacks.java
@@ -184,7 +184,7 @@ public final class Callbacks {
                                 description = callbackVisitor.description;
                             }
                             if (Strings.isNotBlank(callbackVisitor.returnValueDescription)) {
-                                returnValueDescription = callbackVisitor.description;
+                                returnValueDescription = callbackVisitor.returnValueDescription;
                             }
 
                             parameterDescriptions.putAll(callbackVisitor.parameterDescriptions);

--- a/src/main/scripts/lib/lua/devices.lua
+++ b/src/main/scripts/lib/lua/devices.lua
@@ -61,6 +61,10 @@ Device.__tostring = function(self)
         i = i + 1
       end
     end
+
+    if method.returnValueDescription then
+      doc = doc .. "  Returns: " .. method.returnValueDescription .. "\n"
+    end
   end
 
   return doc

--- a/src/main/scripts/lib/micropython/devices.py
+++ b/src/main/scripts/lib/micropython/devices.py
@@ -50,6 +50,10 @@ class Device:
                             doc += "args" + str(i)
                         doc += "  " + p["description"] + "\n"
                     i += 1
+
+            if method.get("returnValueDescription"):
+                doc += f"  Returns: {method['returnValueDescription']}\n"
+
         return doc
 
 


### PR DESCRIPTION
Weʼre already documenting the return values of some RPC methods, but the documentation wasnʼt making it to the computer or the user; this should help.