### PR TITLE
Implement SGR 39 and 49

### DIFF
--- a/src/main/java/li/cil/oc2/common/vm/terminal/Terminal.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/Terminal.java
@@ -136,14 +136,16 @@ public class Terminal {
 
     @SuppressWarnings("unused")
     public static final class Color {
-        static final int BLACK = 0;
-        static final int RED = 1;
-        static final int GREEN = 2;
-        static final int YELLOW = 3;
-        static final int BLUE = 4;
-        static final int MAGENTA = 5;
-        static final int CYAN = 6;
-        static final int WHITE = 7;
+        public static final int BLACK = 0;
+        public static final int RED = 1;
+        public static final int GREEN = 2;
+        public static final int YELLOW = 3;
+        public static final int BLUE = 4;
+        public static final int MAGENTA = 5;
+        public static final int CYAN = 6;
+        public static final int WHITE = 7;
+        public static final int DEFAULT_FG = 8;
+        public static final int DEFAULT_BG = 9;
     }
 
     public enum State { // Must be public for serialization.
@@ -790,6 +792,8 @@ public class Terminal {
             0xFF3ADE, // Magenta
             0x27DDFF, // Cyan
             0xFFFFFF, // White
+            0xEEEEEE, // Default Foreground
+            0x000000, // Default Background
         };
 
         public static final int[] COLORS = {
@@ -801,6 +805,8 @@ public class Terminal {
             0xDD33CC, // Magenta
             0x22CCDD, // Cyan
             0xEEEEEE, // White
+            0xEEEEEE, // Default Foreground
+            0x000000, // Default Background
         };
 
         public static final int[] DIM_COLORS = {
@@ -812,6 +818,8 @@ public class Terminal {
             0x771177, // Magenta
             0x116677, // Cyan
             0x777777, // White
+            0xEEEEEE, // Default Foreground
+            0x000000, // Default Background
         };
 
         public static final int[] COLORS_256 = {

--- a/src/main/java/li/cil/oc2/common/vm/terminal/escapes/csi/SGR.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/escapes/csi/SGR.java
@@ -78,9 +78,19 @@ public class SGR extends CSISequenceHandler {
                 terminal.currentForegroundColorMode = Terminal.ColorMode.SIXTEEN_COLOR;
                 terminal.sixteenColor.R = arg - 30;
             }
+            case 39 -> { // Default foreground color
+                terminal.currentForegroundColorMode = Terminal.ColorMode.SIXTEEN_COLOR;
+                terminal.foregroundColor = Terminal.DEFAULT_TRUE_COLOR_FOREGROUND.Copy();
+                terminal.sixteenColor.R = Terminal.Color.DEFAULT_FG;
+            }
             case 40, 41, 42, 43, 44, 45, 46, 47 -> { // Set background color
                 terminal.currentBackgroundColorMode = Terminal.ColorMode.SIXTEEN_COLOR;
                 terminal.sixteenColor.G = arg - 40;
+            }
+            case 49 -> { // Default background color
+                terminal.currentBackgroundColorMode = Terminal.ColorMode.SIXTEEN_COLOR;
+                terminal.backgroundColor = Terminal.DEFAULT_TRUE_COLOR_BACKGROUND.Copy();
+                terminal.sixteenColor.G = Terminal.Color.DEFAULT_BG;
             }
             case 90, 91, 92, 93, 94, 95, 96, 97 -> { // Set foreground color
                 terminal.currentForegroundColorMode = Terminal.ColorMode.SIXTEEN_COLOR_BRIGHT;


### PR DESCRIPTION
Escape sequences SGR 39 and 49 were not implemented which caused the terminal to be unable to reset to the default foreground / background, respectively. This is mostly a problem with programs like tmux which heavily rely on these escape sequences.

# Example
The problem is clear to see when using the `tmux` clock (shown using `C-b t`)
## Without SGR 49 implemented:
<img width="749" height="451" alt="no-49" src="https://github.com/user-attachments/assets/b734f779-b5bb-43c5-85b9-d2b46762cf7b" />


## With SGR 49 implemented:
<img width="1121" height="662" alt="with-49" src="https://github.com/user-attachments/assets/ffe83dde-2f8e-4901-b2ac-70a145b63daa" />
