### PR TITLE
[Lua] Allow changing bus path with env variable

### DIFF
--- a/src/main/scripts/lib/lua/devices.lua
+++ b/src/main/scripts/lib/lua/devices.lua
@@ -279,4 +279,4 @@ function DeviceBus:invoke(deviceId, methodName, ...)
   end
 end
 
-return DeviceBus:new("/dev/hvc0")
+return DeviceBus:new(os.getenv("OC2R_BUS_PATH") or "/dev/hvc0")


### PR DESCRIPTION
This is useful for intercepting the primary bus with eg. socat.  It will also be useful during migration if the bus path changes in the future.

(I do want to move the canonical bus path in the future, but until thatʼs all sorted out Iʼm not making a PR for anything which is *only* good if that happens.)